### PR TITLE
feat: redirect logged-in users from / to /chat

### DIFF
--- a/app/(root1)/(home)/page.tsx
+++ b/app/(root1)/(home)/page.tsx
@@ -1,4 +1,13 @@
-export default function Page() {
+import { auth } from "@clerk/nextjs/server";
+import { redirect } from "next/navigation";
+
+export default async function Page() {
+  const { userId } = await auth();
+  
+  if (userId) {
+    redirect("/chat");
+  }
+
   return (
     <div className="px-4 max-w-full">
       <div className="flex flex-wrap justify-center gap-6 my-8">

--- a/app/(root1)/(home)/page.tsx
+++ b/app/(root1)/(home)/page.tsx
@@ -1,14 +1,23 @@
-import { auth } from "@clerk/nextjs/server";
-import { redirect } from "next/navigation";
+import { Suspense } from "react";
 
-export default async function Page() {
+async function RedirectHandler() {
+  const { auth } = await import("@clerk/nextjs/server");
+  const { redirect } = await import("next/navigation");
   const { userId } = await auth();
   
   if (userId) {
     redirect("/chat");
   }
+  
+  return null;
+}
 
+export default function Page() {
   return (
+    <>
+      <Suspense fallback={null}>
+        <RedirectHandler />
+      </Suspense>
     <div className="px-4 max-w-full">
       <div className="flex flex-wrap justify-center gap-6 my-8">
         {/* GitHub Icon */}
@@ -79,6 +88,7 @@ export default async function Page() {
           </svg>
         </a>
       </div>
-    </div>
+      </div>
+    </>
   );
 }


### PR DESCRIPTION
Fixes ##13

This PR implements automatic redirect functionality for authenticated users accessing the root path "/". When a logged-in user visits the homepage, they are now automatically redirected to "/chat".

**Changes:**
- Modified the root page component to check authentication status
- Added server-side redirect logic using Clerk auth and Next.js redirect
- Maintained existing homepage functionality for unauthenticated users

**Testing:**
- Authenticated users visiting "/" are redirected to "/chat"
- Unauthenticated users continue to see the homepage with social links

Generated with [Claude Code](https://claude.ai/code)