### PR TITLE
fix: improve send button positioning on chat pages

### DIFF
--- a/app/chat/conversation/[id]/client-page.tsx
+++ b/app/chat/conversation/[id]/client-page.tsx
@@ -157,19 +157,19 @@ export default function ClientPage({
                 ref={inputRef}
                 className="mx-auto w-full max-w-[min(100vw,55rem)] p-4 sm:p-6"
               >
-                <div className="relative">
+                <div className="flex items-end gap-2">
                   <textarea
                     ref={textareaRef}
                     value={inputValue}
                     onChange={(e) => setInputValue(e.target.value)}
                     placeholder="Type your message here..."
-                    className="input-modern resize-none min-h-[3rem] pr-14"
+                    className="input-modern resize-none min-h-[3rem] flex-1"
                     rows={2}
                   />
                   <button
                     type="submit"
                     disabled={!inputValue.trim()}
-                    className="absolute bottom-3 right-3 p-2.5 bg-gradient-to-r from-indigo-600 to-indigo-700 text-white rounded-xl hover:from-indigo-700 hover:to-indigo-800 disabled:from-gray-300 disabled:to-gray-400 disabled:cursor-not-allowed cursor-pointer transition-all duration-200 shadow-md hover:shadow-lg transform hover:-translate-y-0.5 disabled:hover:transform-none"
+                    className="flex-shrink-0 p-3 bg-gradient-to-r from-indigo-600 to-indigo-700 text-white rounded-xl hover:from-indigo-700 hover:to-indigo-800 disabled:from-gray-300 disabled:to-gray-400 disabled:cursor-not-allowed cursor-pointer transition-all duration-200 shadow-md hover:shadow-lg transform hover:-translate-y-0.5 disabled:hover:transform-none"
                     aria-label="Send message"
                   >
                     <RenderFromPending

--- a/app/chat/page.tsx
+++ b/app/chat/page.tsx
@@ -94,17 +94,17 @@ const NewChat = ({ userId }: { userId: string }) => {
           }}
           className="w-full max-w-2xl"
         >
-          <div className="relative">
+          <div className="flex items-center gap-2">
             <input
               name="prompt"
               type="text"
               placeholder="Type your message and press Enter to start chatting..."
-              className="w-full px-4 py-3 pr-16 border border-gray-300 rounded-xl text-lg focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:border-transparent shadow-sm transition-all duration-200"
+              className="flex-1 px-4 py-3 border border-gray-300 rounded-xl text-lg focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:border-transparent shadow-sm transition-all duration-200"
               autoFocus
             />
             <button
               type="submit"
-              className="absolute right-2 top-1/2 transform -translate-y-1/2 p-2.5 bg-gradient-to-r from-indigo-600 to-indigo-700 text-white rounded-lg hover:from-indigo-700 hover:to-indigo-800 transition-all duration-200 shadow-md hover:shadow-lg"
+              className="flex-shrink-0 p-3 bg-gradient-to-r from-indigo-600 to-indigo-700 text-white rounded-xl hover:from-indigo-700 hover:to-indigo-800 transition-all duration-200 shadow-md hover:shadow-lg"
               aria-label="Start chat"
             >
               <svg


### PR DESCRIPTION
Replace absolute positioning with flex layout to resolve UI positioning issues:
- Main chat page: Use flex items-center with gap for better alignment
- Conversation page: Use flex items-end for textarea/button alignment
- Remove pr-14/pr-16 padding that compensated for absolute positioning
- Button now uses flex-shrink-0 for consistent sizing

Fixes #17

🤖 Generated with [Claude Code](https://claude.ai/code)