### PR TITLE
fix: remove vertical stretching from send button on chat home page

### DIFF
--- a/app/chat/page.tsx
+++ b/app/chat/page.tsx
@@ -107,21 +107,25 @@ const NewChat = ({ userId }: { userId: string }) => {
               className="flex-shrink-0 p-3 bg-gradient-to-r from-indigo-600 to-indigo-700 text-white rounded-xl hover:from-indigo-700 hover:to-indigo-800 transition-all duration-200 shadow-md hover:shadow-lg"
               aria-label="Start chat"
             >
-              <svg
-                className="h-5 w-5"
-                viewBox="0 0 24 24"
-                fill="none"
-                stroke="currentColor"
-                strokeWidth="2"
-                strokeLinecap="round"
-                strokeLinejoin="round"
-              >
-                <line x1="22" y1="2" x2="11" y2="13"></line>
-                <polygon points="22 2 15 22 11 13 2 9 22 2"></polygon>
-              </svg>
-              <span className="ml-1">
-                <SpinnerInForm />
-              </span>
+              <RenderFromPending
+                pendingNode={
+                  <div className="h-5 w-5 rounded-full border-2 border-white border-t-transparent animate-spin" />
+                }
+                notPendingNode={
+                  <svg
+                    className="h-5 w-5"
+                    viewBox="0 0 24 24"
+                    fill="none"
+                    stroke="currentColor"
+                    strokeWidth="2"
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                  >
+                    <line x1="22" y1="2" x2="11" y2="13"></line>
+                    <polygon points="22 2 15 22 11 13 2 9 22 2"></polygon>
+                  </svg>
+                }
+              />
             </button>
           </div>
         </form>


### PR DESCRIPTION
Replace problematic button content that had both SVG icon and SpinnerInForm with RenderFromPending component for conditional rendering. This matches the pattern used in conversation detail page and eliminates vertical stretching caused by multiple elements in the button.

Fixes #20

Generated with [Claude Code](https://claude.ai/code)