### PR TITLE
fix: resolve multiple ClerkProvider components error

### DIFF
--- a/app/chat/layout.tsx
+++ b/app/chat/layout.tsx
@@ -39,10 +39,12 @@ export default function RootLayout({
         />
       </head>
       <body className="antialiased bg-grey-50">
-        <Suspense>
-          <TopNav />
-          {children}
-        </Suspense>
+        <ClerkProvider afterSignOutUrl="/chat">
+          <Suspense>
+            <TopNav />
+            {children}
+          </Suspense>
+        </ClerkProvider>
       </body>
     </html>
   );
@@ -116,11 +118,9 @@ const TopNav = () => {
 const ClerkUserButton = () => {
   return (
     <div className="w-[32px] h-[32px] rounded-lg border border-gray-200 bg-white/80 backdrop-blur-sm hover:bg-white transition-colors">
-      <ClerkProvider afterSignOutUrl="/chat">
-        <SignedIn>
-          <UserButton />
-        </SignedIn>
-      </ClerkProvider>
+      <SignedIn>
+        <UserButton />
+      </SignedIn>
     </div>
   );
 };

--- a/app/chat/layout.tsx
+++ b/app/chat/layout.tsx
@@ -39,12 +39,12 @@ export default function RootLayout({
         />
       </head>
       <body className="antialiased bg-grey-50">
-        <ClerkProvider afterSignOutUrl="/chat">
-          <Suspense>
+        <Suspense>
+          <ClerkProvider afterSignOutUrl="/chat">
             <TopNav />
             {children}
-          </Suspense>
-        </ClerkProvider>
+          </ClerkProvider>
+        </Suspense>
       </body>
     </html>
   );

--- a/app/chat/login/[[...catch-all]]/page.tsx
+++ b/app/chat/login/[[...catch-all]]/page.tsx
@@ -1,11 +1,9 @@
-import { SignIn, ClerkProvider } from "@clerk/nextjs";
+import { SignIn } from "@clerk/nextjs";
 
 export default function Page() {
   return (
-    <ClerkProvider afterSignOutUrl="/chat">
-      <div className="flex justify-center items-center min-h-[70vh]">
-        <SignIn forceRedirectUrl="/chat" signUpForceRedirectUrl="/chat" />
-      </div>
-    </ClerkProvider>
+    <div className="flex justify-center items-center min-h-[70vh]">
+      <SignIn forceRedirectUrl="/chat" signUpForceRedirectUrl="/chat" />
+    </div>
   );
 }


### PR DESCRIPTION
Fixes #30

This PR resolves the multiple ClerkProvider components error by:

- Moving ClerkProvider to wrap entire chat layout instead of individual components
- Removing ClerkProvider from ClerkUserButton component in chat layout
- Removing ClerkProvider from login page to prevent nesting
- Ensuring single ClerkProvider instance across chat section

Generated with [Claude Code](https://claude.ai/code)