### PR TITLE
Replace ViewTransition with CSS view transitions and optimize code

### DIFF
--- a/app/(root1)/(home)/header.tsx
+++ b/app/(root1)/(home)/header.tsx
@@ -1,17 +1,17 @@
 "use client";
 
-import { unstable_ViewTransition as ViewTransition } from "react";
 import { useSelectedPage } from "./use-selected-page";
 
 export const Header = () => {
   const selectedPage = useSelectedPage();
   return (
     <div className="absolute top-8 left-8 z-10">
-      <ViewTransition name={selectedPage}>
-        <h1 className="text-6xl font-bold tracking-tight uppercase">
-          {selectedPage}
-        </h1>
-      </ViewTransition>
+      <h1
+        className="text-6xl font-bold tracking-tight uppercase"
+        style={{ viewTransitionName: selectedPage }}
+      >
+        {selectedPage}
+      </h1>
     </div>
   );
 };

--- a/app/(root1)/(home)/menu.tsx
+++ b/app/(root1)/(home)/menu.tsx
@@ -1,42 +1,47 @@
 "use client";
 
-import { unstable_ViewTransition as ViewTransition } from "react";
-
 import Link from "next/link";
 import { useSelectedPage } from "./use-selected-page";
+import { cn } from "@/lib/utils";
+
+interface LinkProps extends React.ComponentProps<typeof Link> {
+  label: string;
+}
+
+const links: LinkProps[] = [
+  { href: "/", label: "home" },
+  { href: "/work", label: "work" },
+  { href: "/article", label: "article" },
+  { href: "/app", label: "app" },
+];
+
 export function Menu() {
+  const selectedPage = useSelectedPage();
+
   return (
     <div className="fixed bottom-8 right-8 text-center">
-      {[
-        { href: "/", label: "home" },
-        { href: "/work", label: "work" },
-        { href: "/article", label: "article" },
-        { href: "/app", label: "app" },
-      ].map((link, index) => (
-        <HeroLink key={index} link={link} />
-      ))}
+      {links.map(
+        (props, index) =>
+          selectedPage !== props.label && <HeroLink key={index} {...props} />,
+      )}
     </div>
   );
 }
 
-const HeroLink = ({ link }: { link: { href: string; label: string } }) => {
-  const selectedPage = useSelectedPage();
-
-  if (selectedPage === link.label) {
-    return null;
-  }
-
+const HeroLink = ({ label, className, ...rest }: LinkProps) => {
   return (
-    <ViewTransition name={link.label}>
-      <Link
-        href={link.href}
-        className="block relative overflow-hidden group py-1 uppercase font-bold tracking-tight w-[80px]"
-      >
-        <span className="relative z-10 transition-colors duration-200 group-hover:text-white dark:group-hover:text-black">
-          {link.label}
-        </span>
-        <span className="absolute inset-0 w-0 bg-black dark:bg-white transition-all duration-200 ease-out group-hover:w-full" />
-      </Link>
-    </ViewTransition>
+    <Link
+      style={{ viewTransitionName: label }}
+      {...rest}
+      className={cn(
+        "block relative overflow-hidden group py-1 uppercase font-bold tracking-tight w-[80px]",
+        className,
+      )}
+    >
+      <span className="relative z-10 transition-colors duration-200 group-hover:text-white dark:group-hover:text-black">
+        {label}
+      </span>
+      <span className="absolute inset-0 w-0 bg-black dark:bg-white transition-all duration-200 ease-out group-hover:w-full" />
+    </Link>
   );
 };

--- a/app/(root1)/(home)/use-selected-page.ts
+++ b/app/(root1)/(home)/use-selected-page.ts
@@ -2,10 +2,4 @@
 
 import { useSelectedLayoutSegment } from "next/navigation";
 
-export const useSelectedPage = () => {
-  let segment = useSelectedLayoutSegment();
-  if (segment === null) {
-    segment = "home";
-  }
-  return segment;
-};
+export const useSelectedPage = () => useSelectedLayoutSegment() ?? "home";


### PR DESCRIPTION
## Replace ViewTransition with CSS view transitions and optimize code

ViewTransition is not stable yet, but we can use css view to implement it
Move the link list outside to prevent duplicate creation
Optimize component structure to reduce calls to `useSelectedPage` hook

## Changes
- Remove `ViewTranslation`
- Refactor `menu.tsx`
- Optimize `useSelectedPage` hook

## Refer to a related PR or issue link
Fixes #34 